### PR TITLE
Update to match Sakai Vue 4.3.0 changes

### DIFF
--- a/components.d.ts
+++ b/components.d.ts
@@ -14,12 +14,9 @@ declare module 'vue' {
     Column: typeof import('primevue/column')['default']
     DataTable: typeof import('primevue/datatable')['default']
     DataView: typeof import('primevue/dataview')['default']
-    InputSwitch: typeof import('primevue/inputswitch')['default']
-    Menu: typeof import('primevue/menu')['default']
     Rating: typeof import('primevue/rating')['default']
     RouterLink: typeof import('vue-router')['RouterLink']
     RouterView: typeof import('vue-router')['RouterView']
     SelectButton: typeof import('primevue/selectbutton')['default']
-    Sidebar: typeof import('primevue/sidebar')['default']
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,15 +8,15 @@
             "name": "your-project",
             "version": "0.0.0",
             "dependencies": {
-                "@primevue/themes": "^4.2.4",
+                "@primeuix/themes": "^1.0.0",
                 "chart.js": "3.3.2",
                 "primeicons": "^7.0.0",
-                "primevue": "^4.2.4",
+                "primevue": "^4.3.1",
                 "vue": "^3.4.34",
                 "vue-router": "^4.4.0"
             },
             "devDependencies": {
-                "@primevue/auto-import-resolver": "^4.2.4",
+                "@primevue/auto-import-resolver": "^4.3.1",
                 "@rushstack/eslint-patch": "^1.8.0",
                 "@vitejs/plugin-vue": "^5.0.5",
                 "@vue/eslint-config-prettier": "^9.0.0",
@@ -27,7 +27,7 @@
                 "prettier": "^3.2.5",
                 "sass": "^1.55.0",
                 "tailwindcss": "^3.4.6",
-                "tailwindcss-primeui": "^0.3.2",
+                "tailwindcss-primeui": "^0.5.0",
                 "unplugin-vue-components": "^0.27.3",
                 "vite": "^5.3.1"
             }
@@ -703,80 +703,144 @@
                 "url": "https://opencollective.com/unts"
             }
         },
-        "node_modules/@primeuix/styled": {
-            "version": "0.3.2",
-            "resolved": "https://registry.npmjs.org/@primeuix/styled/-/styled-0.3.2.tgz",
-            "integrity": "sha512-ColZes0+/WKqH4ob2x8DyNYf1NENpe5ZguOvx5yCLxaP8EIMVhLjWLO/3umJiDnQU4XXMLkn2mMHHw+fhTX/mw==",
+        "node_modules/@primeuix/styles": {
+            "version": "1.2.5",
+            "resolved": "https://registry.npmjs.org/@primeuix/styles/-/styles-1.2.5.tgz",
+            "integrity": "sha512-nypFRct/oaaBZqP4jinT0puW8ZIfs4u+l/vqUFmJEPU332fl5ePj6DoOpQgTLzo3OfmvSmz5a5/5b4OJJmmi7Q==",
+            "license": "MIT",
             "dependencies": {
-                "@primeuix/utils": "^0.3.2"
+                "@primeuix/styled": "^0.7.3"
+            }
+        },
+        "node_modules/@primeuix/styles/node_modules/@primeuix/styled": {
+            "version": "0.7.4",
+            "resolved": "https://registry.npmjs.org/@primeuix/styled/-/styled-0.7.4.tgz",
+            "integrity": "sha512-QSO/NpOQg8e9BONWRBx9y8VGMCMYz0J/uKfNJEya/RGEu7ARx0oYW0ugI1N3/KB1AAvyGxzKBzGImbwg0KUiOQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@primeuix/utils": "^0.6.1"
             },
             "engines": {
                 "node": ">=12.11.0"
             }
         },
-        "node_modules/@primeuix/utils": {
-            "version": "0.3.2",
-            "resolved": "https://registry.npmjs.org/@primeuix/utils/-/utils-0.3.2.tgz",
-            "integrity": "sha512-B+nphqTQeq+i6JuICLdVWnDMjONome2sNz0xI65qIOyeB4EF12CoKRiCsxuZ5uKAkHi/0d1LqlQ9mIWRSdkavw==",
+        "node_modules/@primeuix/styles/node_modules/@primeuix/utils": {
+            "version": "0.6.3",
+            "resolved": "https://registry.npmjs.org/@primeuix/utils/-/utils-0.6.3.tgz",
+            "integrity": "sha512-/SLNQSKQ73WbBIsflKVqbpVjCfFYvQO3Sf1LMheXyxh8JqxO4M63dzP56wwm9OPGuCQ6MYOd2AHgZXz+g7PZcg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=12.11.0"
+            }
+        },
+        "node_modules/@primeuix/themes": {
+            "version": "1.2.5",
+            "resolved": "https://registry.npmjs.org/@primeuix/themes/-/themes-1.2.5.tgz",
+            "integrity": "sha512-n3YkwJrHQaEESc/D/A/iD815sxp8cKnmzscA6a8Tm8YvMtYU32eCahwLLe6h5rywghVwxASWuG36XBgISYOIjQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@primeuix/styled": "^0.7.3"
+            }
+        },
+        "node_modules/@primeuix/themes/node_modules/@primeuix/styled": {
+            "version": "0.7.4",
+            "resolved": "https://registry.npmjs.org/@primeuix/styled/-/styled-0.7.4.tgz",
+            "integrity": "sha512-QSO/NpOQg8e9BONWRBx9y8VGMCMYz0J/uKfNJEya/RGEu7ARx0oYW0ugI1N3/KB1AAvyGxzKBzGImbwg0KUiOQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@primeuix/utils": "^0.6.1"
+            },
+            "engines": {
+                "node": ">=12.11.0"
+            }
+        },
+        "node_modules/@primeuix/themes/node_modules/@primeuix/utils": {
+            "version": "0.6.3",
+            "resolved": "https://registry.npmjs.org/@primeuix/utils/-/utils-0.6.3.tgz",
+            "integrity": "sha512-/SLNQSKQ73WbBIsflKVqbpVjCfFYvQO3Sf1LMheXyxh8JqxO4M63dzP56wwm9OPGuCQ6MYOd2AHgZXz+g7PZcg==",
+            "license": "MIT",
             "engines": {
                 "node": ">=12.11.0"
             }
         },
         "node_modules/@primevue/auto-import-resolver": {
-            "version": "4.2.5",
-            "resolved": "https://registry.npmjs.org/@primevue/auto-import-resolver/-/auto-import-resolver-4.2.5.tgz",
-            "integrity": "sha512-+jeH7QhzyKYYo1yWvJ/HDeHWTddvIbtI6/Gr4pY0hW94RHvRXlnWS20lrXGQ60P/3pkl6p423wysY1hhvsMUjQ==",
+            "version": "4.4.1",
+            "resolved": "https://registry.npmjs.org/@primevue/auto-import-resolver/-/auto-import-resolver-4.4.1.tgz",
+            "integrity": "sha512-DojDr7rc60gHfax6UD9Re2kBmzy7gXtEBOKXarY8AW4TWWOs0pgBzbY6ejWAks9gAh8EYMOE3loNlrd6+Fgc3A==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "@primevue/metadata": "4.2.5"
+                "@primevue/metadata": "4.4.1"
             },
             "engines": {
                 "node": ">=12.11.0"
             }
         },
         "node_modules/@primevue/core": {
-            "version": "4.2.5",
-            "resolved": "https://registry.npmjs.org/@primevue/core/-/core-4.2.5.tgz",
-            "integrity": "sha512-+oWBIQs5dLd2Ini4KEVOlvPILk989EHAskiFS3R/dz3jeOllJDMZFcSp8V9ddV0R3yDaPdLVkfHm2Q5t42kU2Q==",
+            "version": "4.4.1",
+            "resolved": "https://registry.npmjs.org/@primevue/core/-/core-4.4.1.tgz",
+            "integrity": "sha512-RG56iDKIJT//EtntjQzOiWOHZZJczw/qWWtdL5vFvw8/QDS9DPKn8HLpXK7N5Le6KK1MLXUsxoiGTZK+poUFUg==",
+            "license": "MIT",
             "dependencies": {
-                "@primeuix/styled": "^0.3.2",
-                "@primeuix/utils": "^0.3.2"
+                "@primeuix/styled": "^0.7.4",
+                "@primeuix/utils": "^0.6.1"
             },
             "engines": {
                 "node": ">=12.11.0"
             },
             "peerDependencies": {
-                "vue": "^3.3.0"
+                "vue": "^3.5.0"
+            }
+        },
+        "node_modules/@primevue/core/node_modules/@primeuix/styled": {
+            "version": "0.7.4",
+            "resolved": "https://registry.npmjs.org/@primeuix/styled/-/styled-0.7.4.tgz",
+            "integrity": "sha512-QSO/NpOQg8e9BONWRBx9y8VGMCMYz0J/uKfNJEya/RGEu7ARx0oYW0ugI1N3/KB1AAvyGxzKBzGImbwg0KUiOQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@primeuix/utils": "^0.6.1"
+            },
+            "engines": {
+                "node": ">=12.11.0"
+            }
+        },
+        "node_modules/@primevue/core/node_modules/@primeuix/utils": {
+            "version": "0.6.3",
+            "resolved": "https://registry.npmjs.org/@primeuix/utils/-/utils-0.6.3.tgz",
+            "integrity": "sha512-/SLNQSKQ73WbBIsflKVqbpVjCfFYvQO3Sf1LMheXyxh8JqxO4M63dzP56wwm9OPGuCQ6MYOd2AHgZXz+g7PZcg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=12.11.0"
             }
         },
         "node_modules/@primevue/icons": {
-            "version": "4.2.5",
-            "resolved": "https://registry.npmjs.org/@primevue/icons/-/icons-4.2.5.tgz",
-            "integrity": "sha512-WFbUMZhQkXf/KmwcytkjGVeJ9aGEDXjP3uweOjQZMmRdEIxFnqYYpd90wE90JE1teZn3+TVnT4ZT7ejGyEXnFQ==",
+            "version": "4.4.1",
+            "resolved": "https://registry.npmjs.org/@primevue/icons/-/icons-4.4.1.tgz",
+            "integrity": "sha512-UfDimrIjVdY6EziwieyV4zPKzW6mnKHKhy4Dgyjv2oI6pNeuim+onbJo1ce22PEGXW78vfblG/3/JIzVHFweqQ==",
+            "license": "MIT",
             "dependencies": {
-                "@primeuix/utils": "^0.3.2",
-                "@primevue/core": "4.2.5"
+                "@primeuix/utils": "^0.6.1",
+                "@primevue/core": "4.4.1"
             },
+            "engines": {
+                "node": ">=12.11.0"
+            }
+        },
+        "node_modules/@primevue/icons/node_modules/@primeuix/utils": {
+            "version": "0.6.3",
+            "resolved": "https://registry.npmjs.org/@primeuix/utils/-/utils-0.6.3.tgz",
+            "integrity": "sha512-/SLNQSKQ73WbBIsflKVqbpVjCfFYvQO3Sf1LMheXyxh8JqxO4M63dzP56wwm9OPGuCQ6MYOd2AHgZXz+g7PZcg==",
+            "license": "MIT",
             "engines": {
                 "node": ">=12.11.0"
             }
         },
         "node_modules/@primevue/metadata": {
-            "version": "4.2.5",
-            "resolved": "https://registry.npmjs.org/@primevue/metadata/-/metadata-4.2.5.tgz",
-            "integrity": "sha512-dABQ8BecGg6NRnrLx11MvmCQCFn2inUEmao8t17/Tc2wxwoXY315TaakDa5ebOdYnTG91lh+NX7SBpTH+MYIyQ==",
+            "version": "4.4.1",
+            "resolved": "https://registry.npmjs.org/@primevue/metadata/-/metadata-4.4.1.tgz",
+            "integrity": "sha512-fvUVYqzF2Us/NNWXyvO2jFZu4mBk/fkquosmxMrWMULzVbjjptiTdvKWWL5AouATi/w/X1LfMg2dwiA/tbbx6g==",
             "dev": true,
-            "engines": {
-                "node": ">=12.11.0"
-            }
-        },
-        "node_modules/@primevue/themes": {
-            "version": "4.2.5",
-            "resolved": "https://registry.npmjs.org/@primevue/themes/-/themes-4.2.5.tgz",
-            "integrity": "sha512-8F7yA36xYIKtNuAuyBdZZEks/bKDwlhH5WjpqGGB0FdwfAEoBYsynQ5sdqcT2Lb/NsajHmS5lc++Ttlvr1g1Lw==",
-            "dependencies": {
-                "@primeuix/styled": "^0.3.2"
-            },
+            "license": "MIT",
             "engines": {
                 "node": ">=12.11.0"
             }
@@ -2944,15 +3008,38 @@
             "integrity": "sha512-jK3Et9UzwzTsd6tzl2RmwrVY/b8raJ3QZLzoDACj+oTJ0oX7L9Hy+XnVwgo4QVKlKpnP/Ur13SXV/pVh4LzaDw=="
         },
         "node_modules/primevue": {
-            "version": "4.2.5",
-            "resolved": "https://registry.npmjs.org/primevue/-/primevue-4.2.5.tgz",
-            "integrity": "sha512-7UMOIJvdFz4jQyhC76yhNdSlHtXvVpmE2JSo2ndUTBWjWJOkYyT562rQ4ayO+bMdJLtzBGqgY64I9ZfEvNd7vQ==",
+            "version": "4.4.1",
+            "resolved": "https://registry.npmjs.org/primevue/-/primevue-4.4.1.tgz",
+            "integrity": "sha512-JbHBa5k30pZ7mn/z4vYBOnyt5GrR15eM3X0wa3VanonxnFLYkTEx8OMh33aU6ndWeOfi7Ef57dOL3bTH+3f4hQ==",
+            "license": "MIT",
             "dependencies": {
-                "@primeuix/styled": "^0.3.2",
-                "@primeuix/utils": "^0.3.2",
-                "@primevue/core": "4.2.5",
-                "@primevue/icons": "4.2.5"
+                "@primeuix/styled": "^0.7.4",
+                "@primeuix/styles": "^1.2.5",
+                "@primeuix/utils": "^0.6.1",
+                "@primevue/core": "4.4.1",
+                "@primevue/icons": "4.4.1"
             },
+            "engines": {
+                "node": ">=12.11.0"
+            }
+        },
+        "node_modules/primevue/node_modules/@primeuix/styled": {
+            "version": "0.7.4",
+            "resolved": "https://registry.npmjs.org/@primeuix/styled/-/styled-0.7.4.tgz",
+            "integrity": "sha512-QSO/NpOQg8e9BONWRBx9y8VGMCMYz0J/uKfNJEya/RGEu7ARx0oYW0ugI1N3/KB1AAvyGxzKBzGImbwg0KUiOQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@primeuix/utils": "^0.6.1"
+            },
+            "engines": {
+                "node": ">=12.11.0"
+            }
+        },
+        "node_modules/primevue/node_modules/@primeuix/utils": {
+            "version": "0.6.3",
+            "resolved": "https://registry.npmjs.org/@primeuix/utils/-/utils-0.6.3.tgz",
+            "integrity": "sha512-/SLNQSKQ73WbBIsflKVqbpVjCfFYvQO3Sf1LMheXyxh8JqxO4M63dzP56wwm9OPGuCQ6MYOd2AHgZXz+g7PZcg==",
+            "license": "MIT",
             "engines": {
                 "node": ">=12.11.0"
             }
@@ -3424,10 +3511,11 @@
             }
         },
         "node_modules/tailwindcss-primeui": {
-            "version": "0.3.4",
-            "resolved": "https://registry.npmjs.org/tailwindcss-primeui/-/tailwindcss-primeui-0.3.4.tgz",
-            "integrity": "sha512-5+Qfoe5Kpq2Iwrd6umBUb3rQH6b7+pL4jxJUId0Su5agUM6TwCyH5Pyl9R0y3QQB3IRuTxBNmeS11B41f+30zw==",
+            "version": "0.5.1",
+            "resolved": "https://registry.npmjs.org/tailwindcss-primeui/-/tailwindcss-primeui-0.5.1.tgz",
+            "integrity": "sha512-zNqp62N4c+pwBVkVJd8ByvujepVKAMxZBdYy5MzIDi/Zb2p8wTGo4RrQaqLQazm3teOWVmttzZYPH/GlOB3lgw==",
             "dev": true,
+            "license": "MIT",
             "peerDependencies": {
                 "tailwindcss": ">=3.1.0"
             }

--- a/package.json
+++ b/package.json
@@ -8,15 +8,15 @@
         "lint": "eslint . --ext .vue,.js,.jsx,.cjs,.mjs --fix --ignore-path .gitignore"
     },
     "dependencies": {
-        "@primevue/themes": "^4.2.4",
+        "@primeuix/themes": "^1.0.0",
         "chart.js": "3.3.2",
         "primeicons": "^7.0.0",
-        "primevue": "^4.2.4",
+        "primevue": "^4.3.1",
         "vue": "^3.4.34",
         "vue-router": "^4.4.0"
     },
     "devDependencies": {
-        "@primevue/auto-import-resolver": "^4.2.4",
+        "@primevue/auto-import-resolver": "^4.3.1",
         "@rushstack/eslint-patch": "^1.8.0",
         "@vitejs/plugin-vue": "^5.0.5",
         "@vue/eslint-config-prettier": "^9.0.0",
@@ -27,7 +27,7 @@
         "prettier": "^3.2.5",
         "sass": "^1.55.0",
         "tailwindcss": "^3.4.6",
-        "tailwindcss-primeui": "^0.3.2",
+        "tailwindcss-primeui": "^0.5.0",
         "unplugin-vue-components": "^0.27.3",
         "vite": "^5.3.1"
     }

--- a/src/layout/AppConfigurator.vue
+++ b/src/layout/AppConfigurator.vue
@@ -5,7 +5,7 @@ import Aura from '@primeuix/themes/aura';
 import Lara from '@primeuix/themes/lara';
 import { ref } from 'vue';
 
-const { layoutConfig, setPrimary, setSurface, setPreset, isDarkTheme, setMenuMode } = useLayout();
+const { layoutConfig, isDarkTheme } = useLayout();
 
 const presets = {
     Aura,
@@ -167,9 +167,9 @@ function getPresetExt() {
 
 function updateColors(type, color) {
     if (type === 'primary') {
-        setPrimary(color.name);
+        layoutConfig.primary = color.name;
     } else if (type === 'surface') {
-        setSurface(color.name);
+        layoutConfig.surface = color.name;
     }
 
     applyTheme(type, color);
@@ -184,7 +184,7 @@ function applyTheme(type, color) {
 }
 
 function onPresetChange() {
-    setPreset(preset.value);
+    layoutConfig.preset = preset.value;
     const presetValue = presets[preset.value];
     const surfacePalette = surfaces.value.find((s) => s.name === layoutConfig.surface)?.palette;
 
@@ -192,7 +192,7 @@ function onPresetChange() {
 }
 
 function onMenuModeChange() {
-    setMenuMode(menuMode.value);
+    layoutConfig.menuMode = menuMode.value;
 }
 </script>
 

--- a/src/layout/AppConfigurator.vue
+++ b/src/layout/AppConfigurator.vue
@@ -1,8 +1,8 @@
 <script setup>
 import { useLayout } from '@/layout/composables/layout';
-import { $t, updatePreset, updateSurfacePalette } from '@primevue/themes';
-import Aura from '@primevue/themes/aura';
-import Lara from '@primevue/themes/lara';
+import { $t, updatePreset, updateSurfacePalette } from '@primeuix/themes';
+import Aura from '@primeuix/themes/aura';
+import Lara from '@primeuix/themes/lara';
 import { ref } from 'vue';
 
 const { layoutConfig, setPrimary, setSurface, setPreset, isDarkTheme, setMenuMode } = useLayout();

--- a/src/layout/AppLayout.vue
+++ b/src/layout/AppLayout.vue
@@ -5,7 +5,7 @@ import AppFooter from './AppFooter.vue';
 import AppSidebar from './AppSidebar.vue';
 import AppTopbar from './AppTopbar.vue';
 
-const { layoutConfig, layoutState, isSidebarActive, resetMenu } = useLayout();
+const { layoutConfig, layoutState, isSidebarActive } = useLayout();
 
 const outsideClickListener = ref(null);
 
@@ -31,7 +31,9 @@ function bindOutsideClickListener() {
     if (!outsideClickListener.value) {
         outsideClickListener.value = (event) => {
             if (isOutsideClicked(event)) {
-                resetMenu();
+                layoutState.overlayMenuActive = false;
+                layoutState.staticMenuMobileActive = false;
+                layoutState.menuHoverActive = false;
             }
         };
         document.addEventListener('click', outsideClickListener.value);

--- a/src/layout/AppMenuItem.vue
+++ b/src/layout/AppMenuItem.vue
@@ -5,7 +5,7 @@ import { useRoute } from 'vue-router';
 
 const route = useRoute();
 
-const { layoutState, setActiveMenuItem, onMenuToggle } = useLayout();
+const { layoutState, setActiveMenuItem, toggleMenu } = useLayout();
 
 const props = defineProps({
     item: {
@@ -51,7 +51,7 @@ function itemClick(event, item) {
     }
 
     if ((item.to || item.url) && (layoutState.staticMenuMobileActive || layoutState.overlayMenuActive)) {
-        onMenuToggle();
+        toggleMenu();
     }
 
     if (item.command) {

--- a/src/layout/AppTopbar.vue
+++ b/src/layout/AppTopbar.vue
@@ -2,13 +2,13 @@
 import { useLayout } from '@/layout/composables/layout';
 import AppConfigurator from './AppConfigurator.vue';
 
-const { onMenuToggle, toggleDarkMode, isDarkTheme } = useLayout();
+const { toggleMenu, toggleDarkMode, isDarkTheme } = useLayout();
 </script>
 
 <template>
     <div class="layout-topbar">
         <div class="layout-topbar-logo-container">
-            <button class="layout-menu-button layout-topbar-action" @click="onMenuToggle">
+            <button class="layout-menu-button layout-topbar-action" @click="toggleMenu">
                 <i class="pi pi-bars"></i>
             </button>
             <router-link to="/" class="layout-topbar-logo">

--- a/src/layout/composables/layout.js
+++ b/src/layout/composables/layout.js
@@ -1,4 +1,4 @@
-import { computed, reactive, readonly } from 'vue';
+import { computed, reactive } from 'vue';
 
 const layoutConfig = reactive({
     preset: 'Aura',
@@ -19,24 +19,8 @@ const layoutState = reactive({
 });
 
 export function useLayout() {
-    const setPrimary = (value) => {
-        layoutConfig.primary = value;
-    };
-
-    const setSurface = (value) => {
-        layoutConfig.surface = value;
-    };
-
-    const setPreset = (value) => {
-        layoutConfig.preset = value;
-    };
-
     const setActiveMenuItem = (item) => {
         layoutState.activeMenuItem = item.value || item;
-    };
-
-    const setMenuMode = (mode) => {
-        layoutConfig.menuMode = mode;
     };
 
     const toggleDarkMode = () => {
@@ -54,7 +38,7 @@ export function useLayout() {
         document.documentElement.classList.toggle('app-dark');
     };
 
-    const onMenuToggle = () => {
+    const toggleMenu = () => {
         if (layoutConfig.menuMode === 'overlay') {
             layoutState.overlayMenuActive = !layoutState.overlayMenuActive;
         }
@@ -66,12 +50,6 @@ export function useLayout() {
         }
     };
 
-    const resetMenu = () => {
-        layoutState.overlayMenuActive = false;
-        layoutState.staticMenuMobileActive = false;
-        layoutState.menuHoverActive = false;
-    };
-
     const isSidebarActive = computed(() => layoutState.overlayMenuActive || layoutState.staticMenuMobileActive);
 
     const isDarkTheme = computed(() => layoutConfig.darkTheme);
@@ -80,5 +58,15 @@ export function useLayout() {
 
     const getSurface = computed(() => layoutConfig.surface);
 
-    return { layoutConfig: readonly(layoutConfig), layoutState: readonly(layoutState), onMenuToggle, isSidebarActive, isDarkTheme, getPrimary, getSurface, setActiveMenuItem, toggleDarkMode, setPrimary, setSurface, setPreset, resetMenu, setMenuMode };
+    return {
+        layoutConfig,
+        layoutState,
+        toggleMenu,
+        isSidebarActive,
+        isDarkTheme,
+        getPrimary,
+        getSurface,
+        setActiveMenuItem,
+        toggleDarkMode
+    };
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,7 +2,7 @@ import { createApp } from 'vue'
 import App from './App.vue'
 import router from './router'
 
-import Aura from '@primevue/themes/aura'
+import Aura from '@primeuix/themes/aura'
 import PrimeVue from 'primevue/config'
 import ToastService from 'primevue/toastservice'
 import StyleClass from 'primevue/styleclass'


### PR DESCRIPTION
- Upgrade primevue from 4.2.4 to 4.3.1
- Replace @primevue/themes with @primeuix/themes 1.0.0
- Update @primevue/auto-import-resolver to 4.3.1
- Update tailwindcss-primeui to 0.5.0
- Update theme imports in main.ts and AppConfigurator.vue

This update aligns with sakai-vue 4.3.0 release changes.